### PR TITLE
Utilise Pipenv for reproducible builds

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "Tabletop Simulator API"
+
+[packages]
+mkdocs-material = "~= 3.0.4"
+mkdocs = "~=1.0.4"
+pygments = "~=2.2.0"
+pymdown-extensions = "~=5.0"
+
+[requires]
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,118 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "9091b11cacd6c7092757365ef07a19e95e6774ea1ffb0b23ae5945f82f2004b7"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "Tabletop Simulator API",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "click": {
+            "hashes": [
+                "sha256:29f99fc6125fbc931b758dc053b3114e55c77a6e4c6c3a2674a2dc986016381d",
+                "sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b"
+            ],
+            "version": "==6.7"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd",
+                "sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4"
+            ],
+            "version": "==2.10"
+        },
+        "livereload": {
+            "hashes": [
+                "sha256:583179dc8d49b040a9da79bd33de59e160d2a8802b939e304eb359a4419f6498",
+                "sha256:dd4469a8f5a6833576e9f5433f1439c306de15dbbfeceabd32479b1123380fa5"
+            ],
+            "version": "==2.5.2"
+        },
+        "markdown": {
+            "hashes": [
+                "sha256:9ba587db9daee7ec761cfc656272be6aabe2ed300fece21208e4aab2e457bc8f",
+                "sha256:a856869c7ff079ad84a3e19cd87a64998350c2b94e9e08e44270faef33400f81"
+            ],
+            "version": "==2.6.11"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665"
+            ],
+            "version": "==1.0"
+        },
+        "mkdocs": {
+            "hashes": [
+                "sha256:17d34329aad75d5de604b9ed4e31df3a4d235afefdc46ce7b1964fddb2e1e939",
+                "sha256:8cc8b38325456b9e942c981a209eaeb1e9f3f77b493ad755bfef889b9c8d356a"
+            ],
+            "version": "==1.0.4"
+        },
+        "mkdocs-material": {
+            "hashes": [
+                "sha256:2f6987ee2c70f9da0870079a4626f2d309f8528806f08e1a7da842b6c58e7c5c",
+                "sha256:3905942fc8e659bd690420f5fd56bc1f31505067b574377aa8508011389696f0"
+            ],
+            "version": "==3.0.4"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:78f3f434bcc5d6ee09020f92ba487f95ba50f1e3ef83ae96b9d5ffa1bab25c5d",
+                "sha256:dbae1046def0efb574852fab9e90209b23f556367b5a320c0bcb871c77c3e8cc"
+            ],
+            "version": "==2.2.0"
+        },
+        "pymdown-extensions": {
+            "hashes": [
+                "sha256:2e1d8f4a4c351cfa6c5ad88a0f2f4a3a30af481a942fdf8f9db0936e12ff37c2",
+                "sha256:54675680f6ad3ee8242fcb8926703b30ea3dcbeb9e21b7f7f19077f0ec982a82"
+            ],
+            "version": "==5.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
+                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
+                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
+                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
+                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
+                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
+                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
+                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
+                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
+                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
+                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+            ],
+            "version": "==3.13"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "tornado": {
+            "hashes": [
+                "sha256:1c0816fc32b7d31b98781bd8ebc7a9726d7dce67407dc353a2e66e697e138448",
+                "sha256:4f66a2172cb947387193ca4c2c3e19131f1c70fa8be470ddbbd9317fd0801582",
+                "sha256:5327ba1a6c694e0149e7d9126426b3704b1d9d520852a3e4aa9fc8fe989e4046",
+                "sha256:6a7e8657618268bb007646b9eae7661d0b57f13efc94faa33cd2588eae5912c9",
+                "sha256:a9b14804783a1d77c0bd6c66f7a9b1196cbddfbdf8bceb64683c5ae60bd1ec6f",
+                "sha256:c58757e37c4a3172949c99099d4d5106e4d7b63aa0617f9bb24bfbff712c7866",
+                "sha256:d8984742ce86c0855cccecd5c6f54a9f7532c983947cff06f3a0e2115b47f85c"
+            ],
+            "version": "==5.1"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tabletop Simulator API
 
-This is the source of the api documentation in Tabletop Simulator. It uses a modified version of [Material-Design](https://github.com/squidfunk/mkdocs-material) for MKDocs.
+This is the source of the api documentation in Tabletop Simulator. It uses a modified version of [Material-Design](https://github.com/squidfunk/mkdocs-material) for MkDocs.
 
 ## How it Works
 
@@ -8,8 +8,40 @@ The `.md` files in the `/docs` folder are written in Markdown, which is an easy-
 
 Alternatively, you can make modifications to individual pages then submit them for review. The developers will always be the ones to build and publish the site anyway, all you will do is modify the contents of this Git.
 
-### Installing
+## Contributing
 
-If you choose to install MKDocs so you can live-preview your changes, you may do so [by following these instructions](https://squidfunk.github.io/mkdocs-material/getting-started/).
+The API website is built using [MkDocs](https://www.mkdocs.org/) and several related extensions.
 
-Otherwise, you will not need to install anything to edit the text files.
+Pull requests are welcome, however in order to preview your changes, you must follow the instructions below:
+
+### Prerequisites
+
+You will need to ensure Python `3.6` is installed on your system.
+
+If your system doesn't have it installed, you can either [download directly](https://www.python.org/downloads/release/python-366/) or install from a Python version manager such as [pyenv](https://github.com/pyenv/pyenv).
+
+We utilise Pipenv and a `Pipfile` to ensure builds are consistent. If you don't already have Pipenv installed, please follow the official [pipenv install instructions](https://pipenv.readthedocs.io/en/latest/install/#installing-pipenv) for you platform.
+
+### Installing Dependencies
+
+Once've you installed the prerequisites, you must initialize your environment. From command line, this is done with:
+
+```
+pipenv install
+```
+
+You can then "activate" this environment with:
+
+```
+pipenv shell
+```
+
+### Previewing
+
+Once your Pipenv environment is activated, you can simply execute:
+
+```
+mkdocs serve
+```
+
+Then open your browser and navigate to `http://localhost:8000` in order to view your changes.

--- a/theme/partials/nav-item.html
+++ b/theme/partials/nav-item.html
@@ -26,10 +26,8 @@
   {% set class = "md-nav__item md-nav__item--active" %}
 {% endif %}
 
-
 <!-- Main navigation item with nested items -->
 {% if nav_item.children %}
-  <hr style=" border: 0; height: 0; border-top: 1px solid rgba(0, 0, 0, 0.1); border-bottom: 1px solid rgba(255, 255, 255, 0.3);">
   <li class="{{ class }} md-nav__item--nested">
 
     <!-- Active checkbox expands items contained within nested section -->
@@ -70,7 +68,7 @@
 
     <!-- Active checkbox expands items contained within nested section -->
     <input class="md-toggle md-nav__toggle" data-md-toggle="toc"
-        type="checkbox" id="toc" />
+        type="checkbox" id="__toc" />
 
     <!-- Hack: see partials/toc.html for more information -->
     {% if toc_ | first is defined and "\x3ch1 id=" in page.content %}
@@ -79,11 +77,11 @@
 
     <!-- Render table of contents, if not empty -->
     {% if toc_ | first is defined %}
-      <label class="md-nav__link md-nav__link--active" for="toc">
+      <label class="md-nav__link md-nav__link--active" for="__toc">
         {{ nav_item.title }}
       </label>
     {% endif %}
-    <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
+    <a href="{{ nav_item.url | url }}" title="{{ nav_item.title }}"
         class="md-nav__link md-nav__link--active">
       {{ nav_item.title }}
     </a>
@@ -97,7 +95,7 @@
 <!-- Main navigation item -->
 {% else %}
   <li class="{{ class }}">
-    <a href="{{ nav_item.url }}" title="{{ nav_item.title }}"
+    <a href="{{ nav_item.url | url }}" title="{{ nav_item.title }}"
         class="md-nav__link">
       {{ nav_item.title }}
     </a>


### PR DESCRIPTION
Unfortunately, the instructions that are referenced in the README are insufficient to build the documentation. This is because MkDocs does *not* ship with all the extensions that are being utilised.

Additionally, at present, even once all the extensions are installed manually (assuming users know how to do that), the resultant webpage does not work. This is because the provided `nav-item.html` does not work with the latest MkDocs.

Consequently, this pull request includes a `Pipfile`, and more importantly a `Pipfile.lock` so that precise dependency versions can be installed, ensuring everyone building the docs sees the same thing.

I've also:

* Updated the aforementioned `nav-item.html` with the latest official version.
* Updated the README with new build instructions.