### PR TITLE
func_name->table_name|var_name for setVar/Table

### DIFF
--- a/docs/object.md
+++ b/docs/object.md
@@ -239,8 +239,8 @@ getSnapPoints() | Returns a table of sub-tables, each sub-table representing one
 setDecals([<span class="tag tab"></span>](types)&nbsp;parameters) | Sets which decals are on an object. This removes other decals already present, and can remove all decals as well. | [<span class="ret boo"></span>](types) | [<span class="i"></span>](#setdecals)
 <a class="anchor" id="setluascript"></a>setLuaScript([<span class="tag str"></span>](types)&nbsp;script) | Input a string as an entity's Lua script. Generally only used after spawning a new Object. | [<span class="ret boo"></span>](types) |
 setSnapPoints([<span class="tag tab"></span>](types)&nbsp;parameters) | Spawns snap points from a list of parameters. | [<span class="ret boo"></span>](types) | [<span class="i"></span>](#setsnappoints)
-<a class="anchor" id="settable"></a>setTable([<span class="tag str"></span>](types)&nbsp;func_name, [<span class="tag tab"></span>](types)&nbsp;data) | Creates/updates a variable in another entity's script. Only used for tables. | [<span class="ret boo"></span>](types) |
-<a class="anchor" id="setvar"></a>setVar([<span class="tag str"></span>](types)&nbsp;func_name, [<span class="tag var"></span>](types)&nbsp;data) | Creates/updates a variable in another entity's script. Cannot set a table. | [<span class="ret boo"></span>](types) |
+<a class="anchor" id="settable"></a>setTable([<span class="tag str"></span>](types)&nbsp;table_name, [<span class="tag tab"></span>](types)&nbsp;data) | Creates/updates a variable in another entity's script. Only used for tables. | [<span class="ret boo"></span>](types) |
+<a class="anchor" id="setvar"></a>setVar([<span class="tag str"></span>](types)&nbsp;var_name, [<span class="tag var"></span>](types)&nbsp;data) | Creates/updates a variable in another entity's script. Cannot set a table. | [<span class="ret boo"></span>](types) |
 setVectorLines([<span class="tag tab"></span>](types)&nbsp;parameters) | Spawns Vector Lines from a list of parameters on this entity. | [<span class="ret boo"></span>](types) | [<span class="i"></span>](#setvectorlines)
 
 


### PR DESCRIPTION
The `func_name` argument for `setVar` and `setTable` are inadequate. Functions can not be set onto other objects. This change renames them to more sensible argument names