### PR TITLE
Added required "name" attribute for Save&Play

### DIFF
--- a/docs/externaleditorapi.md
+++ b/docs/externaleditorapi.md
@@ -151,11 +151,13 @@ TTS listens for a JSON message with an ID of 1 containing an array of the Lua Sc
     "messageID": 1,
     "scriptStates": [
         {
+	    "name": "Global",
             "guid": "-1",
             "script": "...",
             "ui": "..."
         },
         {
+	    "name": "Block Rectangle",
             "guid": "a0b2d5",
             "script": "..."
         },


### PR DESCRIPTION
I inspected the message Atom sends to the game using Wireshark and found a missing attribute on the docs.

"name" is a required attribute for the command to execute.

This commit fixes the example provided.