### PR TITLE
Remove overwritten padding for active nav links

### DIFF
--- a/docs/css/theme.css
+++ b/docs/css/theme.css
@@ -25,7 +25,6 @@
 [data-md-color-primary=indigo] .md-nav__link--active, [data-md-color-primary=indigo] .md-nav__link:active {
     color: black;
     background-color: #d3d3d3;
-    padding: 2px;
 }
 
 /*Coloring of top bar*/


### PR DESCRIPTION
Currently clicking a nav item causes its height to change, this is especially noticeable in the mobile-style layout with the app drawer, used when the browser width is very small, but also affects other layouts. It causes useability issues, making links hard to click, occasionally causing the wrong link to be clicked. This fixes that.