### PR TITLE
Fix missing text in musicplayer.md

### DIFF
--- a/docs/musicplayer.md
+++ b/docs/musicplayer.md
@@ -22,7 +22,7 @@ getPlaylist() | Gets the current playlist. | [<span class="ret tab"></span>](typ
 pause() | Pauses currently playing audioclip. Returns true if the music player is paused, otherwise returns false. | [<span class="ret boo"></span>](types.md)| [:i:](#pause)
 play() | Plays currently loaded audioclip. Returns true if the music player is playing, otherwise returns false. | [<span class="ret boo"></span>](types.md) | [:i:](#play)
 setCurrentAudioclip() | Sets the audioclip to be loaded. | [<span class="ret boo"></span>](types.md)| [:i:](#setcurrentaudioclip)
-setPlaylist() | Sets the current playlis
+setPlaylist() | Sets the current playlist. | [<span class="ret boo"></span>](types.md)| [:i:](#setplaylist)
 skipBack() | Skips to the beginning of the audioclip or if the play time is less than 3 seconds to the previous audioclip in playlist if possible. Returns true if skip was successful, otherwise returns false. | [<span class="ret boo"></span>](types.md)| [:i:](#skipback)
 skipForward() | Skips to the next audioclip in playlist if possible. Returns true if skip was successful, otherwise returns false. | [<span class="ret boo"></span>](types.md)| [:i:](#skipforward) | [<span class="ret boo"></span>](types.md)| [:i:](#setplaylist)
 


### PR DESCRIPTION
Restores the end of a line of text that had been cut off.